### PR TITLE
Fix inconsistent keywords in example

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -377,7 +377,7 @@ which inserts this:
 To put that same data into the database and add an "edge" somewhere else in the graph you could do:
 
 ```
-(merge/merge-component! app Person {:person/id 11 ...} :append [:list/id :friends :people])
+(merge/merge-component! app Person {:person/id 11 ...} :append [:list/id :friends :list/people])
 ```
 
 which would add this to the graph:


### PR DESCRIPTION
Not sure if the intention was to use `:people` (as defined in `merge-component!` - line 380) or `:list/people` (as defined in the example graph output - line 387)
