### PR TITLE
Update Dynamic Router example to compose router initial state into Root

### DIFF
--- a/src/book/book/dynamic_router_example.cljs
+++ b/src/book/book/dynamic_router_example.cljs
@@ -78,7 +78,7 @@
 
 (defsc Root [this {:root/keys [router]}]
   {:query         [{:root/router (comp/get-query TopRouter)}]
-   :initial-state {:root/router {}}}
+   :initial-state {:root/router (comp/get-initial-state TopRouter {})}}
   (dom/div
     (dom/button {:onClick #(dr/change-route this ["main"])} "Go to main")
     (dom/button {:onClick #(dr/change-route this ["settings"])} "Go to settings")


### PR DESCRIPTION
This fixes the dynamic routing example in the book. Previously, it was implied that one didn't need to compose a Router's initial state into an app root. Now, the initial state composition is explicit.