### PR TITLE
Describe 2 options for transitioning state in UISM

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -7427,6 +7427,37 @@ Basically you do not define an event map, and instead embed a handler in it's pl
                        ...)}}
 ```
 
+== Transitioning State
+
+There are two options for transitioning to another state from within a state:
+
+=== Option 1 -- Call `uism/activate` from within a handler
+
+```
+   ::uism/states
+     {:some-state
+       {::uism/events
+         {:event/some-event
+           {::uism/handler
+             (fn [env]
+               ,,, ; do some thing
+               (uism/activate env :state/some-other-state)}}}
+      :some-other-state {,,,}}
+
+```
+
+=== Option 2 -- Use the `::uism/target-state` keyword shortcut
+
+When you have an event that only changes to another state, the `::uism/target-state` key is simpler
+
+```
+  ::uism/states
+    {:some-state
+      {::uism/events
+        {:event/some-event {::uism/target-state :state/some-other-state}}}
+     :some-other-state {,,,}}
+```
+
 == Writing Handlers and Data Manipulation
 
 From here it's pretty easy.


### PR DESCRIPTION
I find the `::uism/target-state` event handler to  be a convenient helper but there's no mention of it in the docs.  Also, I think this commit helps bring attention to the importance of this and the other primary means of changing state `(uism/activate)`