### PR TITLE
Build It section to use watch instead

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -725,7 +725,7 @@ You can start the compiler server with:
 
 [source,bash]
 ----
-$ npx shadow-cljs server
+$ npx shadow-cljs watch main
 ----
 
 and navigate to the URL it prints out for the compiler server (usually http://localhost:9630).
@@ -735,7 +735,7 @@ It also has hot-code (and CSS) reload built in, so there is no need for any addi
 
 We configured the `shadow-cljs` server to also start a development mode HTTP server to serve our HTML file and javascript.
 So, if you didn't make any typos then your new app should display "TODO" at
-http://localhost:8000.
+http://localhost:8000 once `npx shadow-cljs watch main` has reached `[:main] Build completed.` after about 1 minute.
 
 === Using the REPL
 


### PR DESCRIPTION
`shadow-cljs server` doesn't actually trigger a build so the user would need to click either Watch or Compile under the server UI. This would've tripped me up if I hadn't been using shadow-cljs for a couple of days! : ) It takes about 30 seconds after the HTTP server URL is displayed for shadow-cljs to actually finish the compile and reach the `[:main] Build completed.`  on first execution.