### PR TITLE
Updated Getting Started ClojureScript version bump + warning

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -616,12 +616,14 @@ Create a `deps.edn` file with this content:
            com.fulcrologic/fulcro {:mvn/version "3.0.10"}}
 
  :aliases {:dev {:extra-paths ["src/dev"]
-                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.520"}
+                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.742"}
                                thheller/shadow-cljs        {:mvn/version "2.8.40"}
                                binaryage/devtools          {:mvn/version "0.9.10"}}}}}
 ```
 
 === https://shadow-cljs.github.io/docs/UsersGuide.html[Shadow-cljs] Build Tool Configuration
+
+IMPORTANT: Make sure you are referencing the latest version of ClojureScript that shadow-cljs supports. A verison mismatch may result in a syntax error when running the shadow-cljs server command further down the guide.
 
 And a `shadow-cljs.edn` file that looks like this:
 


### PR DESCRIPTION
- Started the Getting Started guide
- Created deps.edn as described
- Created shadow-cljs.edn as described
- Ran `npx shadow-cljs server`

Encountered the following error:

```
shadow-cljs - config: /Users/jay/Projects/learn-fulcro/shadow-cljs.edn
shadow-cljs - starting via "clojure"
Syntax error (NoSuchFieldError) compiling at (shadow/cljs/devtools/api.clj:1:1).
ES3

Full report at:
/var/folders/kz/c0gjk6g16jn95qnj139kyl480000gn/T/clojure-2781862765009457624.edn
```

Thankfully theller was available in the #fulcro Slack channel. He advised me to bump the ClojureScript version and it started working as advertised. 

To address this:
- Bump to the latest ClojureScript version
- Added an IMPORTANT: notice to inform people that the ClojureScript version in deps.edn needs to match what shadow-cljs is currently using.