### PR TITLE
Updated Getting Started ClojureScript version

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -616,7 +616,7 @@ Create a `deps.edn` file with this content:
            com.fulcrologic/fulcro {:mvn/version "3.0.10"}}
 
  :aliases {:dev {:extra-paths ["src/dev"]
-                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.520"}
+                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.1.10.742"}
                                thheller/shadow-cljs        {:mvn/version "2.8.40"}
                                binaryage/devtools          {:mvn/version "0.9.10"}}}}}
 ```

--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -616,7 +616,7 @@ Create a `deps.edn` file with this content:
            com.fulcrologic/fulcro {:mvn/version "3.0.10"}}
 
  :aliases {:dev {:extra-paths ["src/dev"]
-                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.1.10.742"}
+                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.742"}
                                thheller/shadow-cljs        {:mvn/version "2.8.40"}
                                binaryage/devtools          {:mvn/version "0.9.10"}}}}}
 ```

--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -617,7 +617,7 @@ Create a `deps.edn` file with this content:
 
  :aliases {:dev {:extra-paths ["src/dev"]
                  :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.742"}
-                               thheller/shadow-cljs        {:mvn/version "2.8.40"}
+                               thheller/shadow-cljs        {:mvn/version "2.8.107"}
                                binaryage/devtools          {:mvn/version "0.9.10"}}}}}
 ```
 


### PR DESCRIPTION
Bumped the Getting Started guide ClojureScript version to keep inline with the latest shadow to avoid a breaking error

- Started the Getting Started guide
- Created deps.edn as described
- Created shadow-cljs.edn as described
- Ran `npx shadow-cljs server`

Encountered the following error:

```
shadow-cljs - config: /Users/jay/Projects/learn-fulcro/shadow-cljs.edn
shadow-cljs - starting via "clojure"
Syntax error (NoSuchFieldError) compiling at (shadow/cljs/devtools/api.clj:1:1).
ES3

Full report at:
/var/folders/kz/c0gjk6g16jn95qnj139kyl480000gn/T/clojure-2781862765009457624.edn
```

Thankfully theller was available in the #fulcro Slack channel. He advised me to bump the ClojureScript version and it started working as advertised. 

See #46 for more reasoning from him on why it's required or take a look at this Slack convo if accessible https://clojurians.slack.com/archives/C68M60S4F/p1588086231202800.