### PR TITLE
Add details related to pathom mutation namespacing

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -2367,7 +2367,14 @@ Then create `src/main/app/mutations.clj` and add this code to it:
 
 (pc/defmutation delete-person [env {list-id   :list/id
                                     person-id :person/id}]
-  ;; optional, this is how you override what symbol it responds to.  Defaults to current ns.
+  ;; Pathom registers these mutations in an index. The key that the mutation is
+  ;; indexed by can be overridden with the `::pc/sym`
+  ;; configuration option below. Note, however, that mutation we are sending
+  ;; in the `comp/transact!` from the PersonList component above is
+  ;; `[(api/delete-person ,,,)]` which will expand to the fully qualified
+  ;; mutation of `[(app.mutations/delete-person ,,,)]`. If you
+  ;; encounter unexpected error messages about mutations not being found,
+  ;; ensure any overridden syms match the expanded namespaces of your mutations.
   {::pc/sym `delete-person}
   (log/info "Deleting person" person-id "from list" list-id)
   (swap! list-table update list-id update :list/people (fn [old-list] (filterv #(not= person-id %) old-list))))


### PR DESCRIPTION
While working from the book, I ran into an issue of a mutation not being
found. A google search only showed a single relevant result and it was
from a Slack discussion of someone having the same issue.

Pasted below for reference.

I think these comments are better than nothing. But overriding the
config is optional and if this book is trying to be as kind as possible
to newcomers, it might be better to use fully-qualified names and
defaults in as many places as possible. Maybe the benefit of showing how
to override pathoms default sym is not worth having to explain how the
namespacing works.

=== Begin chat log ===
@wilkerlucio I have some trouble with the pathom remote for Fulcro. I alway get {:message "Mutation not found", :data {:mutation login}} when I make a mutation like so: [(login {...params...}})] I have used the template setup from the developers guide. What am I doing wrong here? I am getting crazy.

(pc/defmutation login [env {:keys [connection nickname password]}]
  {::pc/sym 'login
   ....})

(def my-app-registry [login])

(def parser
  (p/parallel-parser
    {::p/env {...}
     ::p/mutate pc/mutate-async
     ::p/plugin [(pc/connect-plugin {::pc/register my-app-registry})
                 ...]}))

wilkerlucio19:12:33
@mroerni the issue here I think is because you used a simple symbol to define your mutation, that means it has the fully qualified name whatever-ns-you-have/login instead of just login, I suggest you try namespacing it on the server (maybe user/login), of you use that on the definition then you can use directly
=== End chat log ===