### PR TITLE
Explain briefly the need for pre-merge

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -2807,8 +2807,9 @@ The `:pre-merge` lambda receives a single map containing the following keys:
 * `:state-map` - the current normalized client database (as a map, not an atom)
 * `:query` - the query being used to for this request (user may have modified the original using `:focus`, `:without` or `:update-query` during the load call
 
-and returns the data that should actually be merged into app state.
-This feature requires a complete understanding of normalization and full stack operation, and is covered in a
+and returns the data that should actually be merged into app state. You will need it when for example loading
+domain data from the server while also requiring the presence of some ui-only props (such as a child router state
+or form data). This feature requires a complete understanding of normalization and full stack operation, and is covered in a
 <<PreMerge, later chapter>>.
 
 === Component Constructor


### PR DESCRIPTION
When I first read this section, I was scared by the "This feature requires a complete understanding of normalization and full stack operation" and thought that it was and advanced feature that I did not need try understanding anytime soon. The consequence it that it took me longer to discover that this was the correct solution for not breaking a child router when loading data. I think it is valuable to briefly mention the purpose already here so the reader will get an idea when s/he needs to come back to learn more.