### PR TITLE
Partial Routes: can also use :will-mount

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -9084,6 +9084,9 @@ result.
    ...)
 -----
 
+Or you could `change-route-relative!` in the `dr/route-deferred` of a ancestor target's `:will-enter`, if there is one.
+(Just beware infinite transaction loops.)
+
 
 === Targets Denying Routes v3.1.23+
 


### PR DESCRIPTION
For my case, specifying the path to the leaf target in the closet ancestor with a deferred will-enter is a better match then either globally at start or forcing its siblings to know about its internal structure. But it wasn't obvious that this is possibly so I think it is worth documenting it.