### PR TITLE
Updated Fulcro version in deps.edn for the server section

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -2280,7 +2280,7 @@ Open your `deps.edn` file and add dependencies so it looks like this:
 ```
 {:paths   ["src/main" "resources"]
  :deps    {org.clojure/clojure    {:mvn/version "1.10.1"}
-           com.fulcrologic/fulcro {:mvn/version "3.0.10"}
+           com.fulcrologic/fulcro {:mvn/version "3.4.14"}
            com.wsscode/pathom     {:mvn/version "2.2.15"}
            ring/ring-core         {:mvn/version "1.6.3"}
            com.taoensso/timbre    {:mvn/version "4.10.0"}


### PR DESCRIPTION
I copied and pasted the deps.edn listing in the server section and it did not work because of the version.  This requests sets the fulcro dependency to be the same for the client and servers sections.