### PR TITLE
correct signature of transmit!

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -8450,7 +8450,9 @@ You could use the code in `http_remote.cljs` as a starting point.
 Here are the basics:
 
 . A remote is just a map.
-The map can contain anything you want, but *MUST* contain a `:transmit!` key whose value is a `(fn [send-node] )`.
+The map can contain anything you want, but *MUST* contain a `:transmit!` key whose value is a `(fn [remote send-node] )`.
+
+A `remote` is the remote map itself.
 
 A `send-node` has the following spec:
 


### PR DESCRIPTION
As we can [see in the code](https://github.com/fulcrologic/fulcro/blob/7e75d3a806e6ba1a61e517c5f07d7f2ad83918c5/src/main/com/fulcrologic/fulcro/algorithms/tx_processing.cljc#L152), transmit! actually takes two arguments.