### PR TITLE
Update DevelopersGuide.adoc - Getting started deps.edn file

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -1028,21 +1028,16 @@ and a brand-new version of shadow-cljs can lead to confusing build errors.
 
 Create a `deps.edn` file with this content:
 
-```
-{:paths   ["src/main" "resources"]
- :deps    {org.clojure/clojure    {:mvn/version "1.10.1"}
-           com.fulcrologic/fulcro {:mvn/version "3.4.14"}}
+```{:paths   ["src/main" "resources"]
+ :deps    {org.clojure/clojure    {:mvn/version "1.10.3"}
+           com.fulcrologic/fulcro {:mvn/version "3.5.9"}}
 
  :aliases {:dev {:extra-paths ["src/dev"]
-                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.742"}
-                               thheller/shadow-cljs        {:mvn/version "2.8.107"}
-                               binaryage/devtools          {:mvn/version "0.9.10"}}}}}
+                 :extra-deps  {org.clojure/clojurescript   {:mvn/version "1.10.914"}
+                               thheller/shadow-cljs        {:mvn/version "2.16.9"}
+                               binaryage/devtools          {:mvn/version  "1.0.4"}
+                               cider/cider-nrepl           {:mvn/version "0.27.4"}}}}}
 ```
-
-[TIP]
---
-[#clj-kondo]*clj-kondo support*: Fulcro exports configs for the clj-kondo linter (used e.g. by Calva). To import them, create `.clj-kondo/config.edn` containing `{}` and run `clj-kondo --copy-configs --dependencies --lint  (clojure -Spath)` and follow the printed instructions for adding them to the config file.
---
 
 === https://shadow-cljs.github.io/docs/UsersGuide.html[Shadow-cljs] Build Tool Configuration
 


### PR DESCRIPTION
Add cider/cider-nrepl dependency to starter and bump to latest dependency versions

Go To Definition functionality in VSCode using Calva does not work if cider/cider-nrepl is not included in the dependencies.

If you start shadow-cljs from VSCode it will explicitly include it by running
`npx shadow-cljs -d cider/cider-nrepl:0.26.0 watch :main`

Since this guide suggests starting shadow-cljs in server mode this dependency needs to be included in deps or perhaps in the run command later eg `npx shadow-cljs -d cider/cider-nrepl:0.26.0 server`

I also noticed that the Tip below to configure clj-kondo required quoting the lint argument or zsh, but it also did not appear to do anything when I ran it... 

```
➜  first-project git:(master) ✗ cat .clj-kondo/config.edn
{}
➜  first-project git:(master) ✗ clj-kondo --copy-configs --dependencies --lint '(clojure -Spath)'
➜  first-project git:(master) ✗ cat .clj-kondo/config.edn
{}
➜  first-project git:(master) ✗ clj-kondo --copy-configs --dependencies --lint  (clojure -Spath)
zsh: number expected
➜  first-project git:(master) ✗ clj-kondo --copy-configs --dependencies --lint '(clojure -Spath)'
[clj-kondo] Auto-loading config path: com.fulcrologic/fulcro
➜  first-project git:(master) ✗ cat .clj-kondo/config.edn
{}
```
VSCode however is not complaining about defsc or anything so it either this step is no longer necessary (I think clj-kondo can discover config in libraries and now just works) or this command updated something other than the config file.  
Pretty sure this is no longer needed so I removed it... if still needed then perhaps it can be updated to quote the lint argument and better document what the expected result of this is.