### PR TITLE
4.6.3 Update incomplete data tree -> query example

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -1592,14 +1592,14 @@ So, a data tree like this:
 would have a query that looks like this:
 
 ```
-{:friends  ; JOIN
+[{:friends  ; JOIN
     [ :list/label
       {:list/people ; JOIN
          [:person/name :person/age]}]}
- {:enemies  ; JOIN
+ {:friends  ; JOIN
     [ :list/label
       {:list/people ; JOIN
-         [:person/name :person/age]}]}
+         [:person/name :person/age]}]}]
 ```
 
 This query reads "At the root you'll find `:friends`, which joins to a nested entity that has a label and people.

--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -1596,7 +1596,7 @@ would have a query that looks like this:
     [ :list/label
       {:list/people ; JOIN
          [:person/name :person/age]}]}
- {:friends  ; JOIN
+ {:enemies  ; JOIN
     [ :list/label
       {:list/people ; JOIN
          [:person/name :person/age]}]}]

--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -1592,10 +1592,14 @@ So, a data tree like this:
 would have a query that looks like this:
 
 ```
-[{:friends  ; JOIN
+{:friends  ; JOIN
     [ :list/label
       {:list/people ; JOIN
-         [:person/name :person/age]}]}]
+         [:person/name :person/age]}]}
+ {:enemies  ; JOIN
+    [ :list/label
+      {:list/people ; JOIN
+         [:person/name :person/age]}]}
 ```
 
 This query reads "At the root you'll find `:friends`, which joins to a nested entity that has a label and people.


### PR DESCRIPTION
The goal of this PR was to update the incomplete the data tree -> query example in 4.6.3: https://book.fulcrologic.com/#_step_2establishing_a_query

The data tree showed both `friends` and `enemies` components but the query example only showed `friends`.

This was confusing as the EDN notation for a vector with multiple maps may not be intuitive (it wasn't for me).