### PR TITLE
Update adoc syntax so deps.end shows in its entirety in guide

### DIFF
--- a/DevelopersGuide.adoc
+++ b/DevelopersGuide.adoc
@@ -1028,7 +1028,8 @@ and a brand-new version of shadow-cljs can lead to confusing build errors.
 
 Create a `deps.edn` file with this content:
 
-```{:paths   ["src/main" "resources"]
+```
+{:paths   ["src/main" "resources"]
  :deps    {org.clojure/clojure    {:mvn/version "1.10.3"}
            com.fulcrologic/fulcro {:mvn/version "3.5.9"}}
 


### PR DESCRIPTION
The start of the deps.end file was omitted in Clojure Dependencies section of the guide. 
This caused developers who followed the guide verbatim to not be able to run the project.
The cause was the `{:paths   ["src/main" "resources"]` portion needs to start on a newline.